### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
   },
   "require": {
     "php": "^8.1",
-    "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-    "illuminate/process": "^9.0|^10.0|^11.0|^12.0",
-    "illuminate/console": "^9.0|^10.0|^11.0|^12.0"
+    "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+    "illuminate/process": "^9.0|^10.0|^11.0|^12.0|^13.0",
+    "illuminate/console": "^9.0|^10.0|^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",


### PR DESCRIPTION
## Summary

- Adds `^13.0` to `illuminate/support`, `illuminate/process`, and `illuminate/console` version constraints, enabling compatibility with Laravel 13.

No other changes — the package works as-is with Laravel 13.

## Test plan

- [x] Install the package in a Laravel 13 project and verify it resolves without conflict
- [x] Confirm async dispatch works as expected